### PR TITLE
google fact checker was returning a single response it fact checked i…

### DIFF
--- a/fact_checker.py
+++ b/fact_checker.py
@@ -59,11 +59,13 @@ class FactChecker:
             return 'low'
         else:
             return 'unknown'
-
+    
     def _do_fact_check(self, sentence: str, idx: int) -> dict:
         self.logger.debug(
             f"No exact match found. Performing new fact check for: {sentence}")
-        fact_checks = self.get_fact_checks(sentence)
+        #fact_checks = self.get_fact_checks(sentence)
+        fact_checks = '' # return nothing on purpose to skip the Google Fact Checker. It causes broken returns.
+        self.logger.debug(f"Returned Facts: {fact_checks}")
         self.logger.debug(f"Received fact checks for sentence {idx}")
         if 'claims' in fact_checks and fact_checks['claims']:
             relevant_claim = self.find_relevant_claim(


### PR DESCRIPTION
google fact checker was returning a single response it fact checked itself and it was also causing the script to break on the unfamiliar object cast returned, so I commented out line 66 and make fact_check= '' so it skips the google fact checker and contiues on to our custom search, in the future if we want to use it again, just switch the lines out.